### PR TITLE
Parallelize fetching and status gathering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "prettytable-rs",
  "serde",
  "thiserror",
+ "threadpool",
  "toml",
 ]
 
@@ -292,6 +293,16 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -459,6 +470,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "termios",
+ "unicode-width",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +208,7 @@ dependencies = [
  "clap",
  "directories",
  "git2",
+ "indicatif",
  "prettytable-rs",
  "serde",
  "thiserror",
@@ -216,6 +234,18 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -305,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +492,25 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -570,6 +640,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ clap = "2"
 serde = { version = "1.0", features = ["derive"] }
 prettytable-rs = { version = "0.8", default-features = false }
 threadpool = "1.0"
+indicatif = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ directories = "3.0"
 clap = "2"
 serde = { version = "1.0", features = ["derive"] }
 prettytable-rs = { version = "0.8", default-features = false }
+threadpool = "1.0"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It is inspired by [gita](https://github.com/nosarthur/gita.git).
 + [ ] Integration testing
 + [ ] CI
 + [ ] Publish to [crates.io](https://crates.io/)
-+ [ ] Better handling of large repositories
-    + [ ] Parallelization
-    + [ ] Progress feedback (spinners?)
++ [x] Better handling of large repositories
+    + [x] Parallelization
+    + [x] Progress feedback
 
 ## Usage
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ impl Config {
     pub fn repositories(&self) -> &HashMap<String, PathBuf> {
         &self.repositories
     }
+    pub fn repository_count(&self) -> usize {
+        self.repositories.len()
+    }
     pub fn add_repository<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let path = path.as_ref();
         let name = path

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,12 +146,6 @@ fn main() -> Result<()> {
         let handle = thread::spawn(move || {
             if let Ok(mut repository) = Repository::open(&name, path) {
                 if repository.fetch().is_ok() {
-                    // Get distance (ahead / behind remote)
-                    let distance = match repository.distance() {
-                        Some(distance) => distance.to_string(),
-                        None => String::new(),
-                    };
-
                     // Get commit summary and truncate it
                     let commit_summary = if let Ok(summary) = repository.commit_summary() {
                         if summary.chars().count() > 50 {
@@ -169,7 +163,7 @@ fn main() -> Result<()> {
                         repository.name(),
                         repository.status(),
                         repository.branch_name().unwrap_or_default(),
-                        distance,
+                        repository.distance(),
                         repository.remote_name().unwrap_or_default(),
                         commit_summary
                     ]);

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -29,19 +29,17 @@ impl Repository {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn status<'a>(&'a mut self) -> Result<&'a Status> {
+    pub fn status(&mut self) -> &Status {
         if let Status::Unknown = self.status {
-            let status = self
-                .inner
-                .statuses(Some(&mut self.status_options))?
-                .iter()
-                .fold(HashSet::new(), |mut set, s| {
+            if let Ok(statuses) = self.inner.statuses(Some(&mut self.status_options)) {
+                let status = statuses.iter().fold(HashSet::new(), |mut set, s| {
                     set.insert(s.status());
                     set
                 });
-            self.status = Status::Known(status);
+                self.status = Status::Known(status);
+            }
         }
-        Ok(&self.status)
+        &self.status
     }
     pub fn branch_name(&self) -> Option<String> {
         if let Ok(head) = self.inner.head() {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -6,13 +6,12 @@ use std::path::Path;
 
 pub struct Repository {
     inner: git2::Repository,
-    name: String,
     status_options: git2::StatusOptions,
     status: Status,
 }
 
 impl Repository {
-    pub fn open<P: AsRef<Path>>(name: &str, path: P) -> Result<Self> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let repository = git2::Repository::open(path)?;
         let mut status_options = git2::StatusOptions::new();
         status_options
@@ -21,13 +20,9 @@ impl Repository {
             .include_ignored(false);
         Ok(Self {
             inner: repository,
-            name: name.into(),
             status_options,
             status: Status::Unknown,
         })
-    }
-    pub fn name(&self) -> &str {
-        &self.name
     }
     pub fn status(&mut self) -> &Status {
         if let Status::Unknown = self.status {


### PR DESCRIPTION
Because fetching and gathering the files status can take a significant amount of time for large repositories, we run those steps on a [threadpool](https://crates.io/crates/threadpool).

Progress is shown using an [indicatif](https://crates.io/crates/indicatif) progress bar.

The resulting data is sorted alphabetically (on the repository name) and displayed in the table.